### PR TITLE
Fixed type of CognitoEvent version attribute. int => String

### DIFF
--- a/data/cognito_event.json
+++ b/data/cognito_event.json
@@ -1,5 +1,5 @@
 {
-    "version": 1,
+    "version": "1",
     "triggerSource": "CustomMessage_SignUp/CustomMessage_ResendCode/CustomMessage_ForgotPassword/CustomMessage_VerifyUserAttribute",
     "region": "eu-west-1",
     "userPoolId": "1234567",

--- a/lib/events/cognito_event.dart
+++ b/lib/events/cognito_event.dart
@@ -6,7 +6,7 @@ part 'cognito_event.g.dart';
 @JsonSerializable()
 class AwsCognitoEvent extends Event {
   @JsonKey()
-  final int? version;
+  final String? version;
 
   @JsonKey()
   final String? triggerSource;

--- a/lib/events/cognito_event.g.dart
+++ b/lib/events/cognito_event.g.dart
@@ -8,7 +8,7 @@ part of 'cognito_event.dart';
 
 AwsCognitoEvent _$AwsCognitoEventFromJson(Map<String, dynamic> json) {
   return AwsCognitoEvent(
-    version: json['version'] as int?,
+    version: json['version'] as String?,
     triggerSource: json['triggerSource'] as String?,
     region: json['region'] as String?,
     userPoolId: json['userPoolId'] as String?,

--- a/test/cognito_event_test.dart
+++ b/test/cognito_event_test.dart
@@ -14,7 +14,7 @@ void main() {
     test('json got parsed and creates an event', () async {
       final event = AwsCognitoEvent.fromJson(json!);
 
-      expect(event.version, equals(1));
+      expect(event.version, equals('1'));
       expect(event.userPoolId, equals('1234567'));
       expect(event.userName, equals('foo'));
       expect(event.response!.smsMessage, equals('foo'));


### PR DESCRIPTION
version attribute for CognitoEvent comes through as a String. 

```
{
    "version": "1",
    "region": "us-east-1",
    "userPoolId": "us-east-1_eQ3CWqhez",
    "userName": "2b37ddf6-277e-4c4d-b9d7-2e366a85489c",
    "callerContext": {
        "awsSdkVersion": "aws-sdk-unknown-unknown",
        "clientId": "3p3baj8uej3qos8k1ekfg6a4ed"
    },
    "triggerSource": "PostConfirmation_ConfirmSignUp",
    "request": {
        "userAttributes": {
            "sub": "2b37ddf6-277e-4c4d-b9d7-2e366a85489c",
            "birthdate": "1994-06-16",
            "email_verified": "true",
            "cognito:user_status": "CONFIRMED",
            "cognito:email_alias": "*******@******",
            "email": "*******@******"
        }
    },
    "response": {}
}
```