### PR TITLE
bugfix: jsonEncode payload.body not payload itself

### DIFF
--- a/lib/client/client.dart
+++ b/lib/client/client.dart
@@ -1,6 +1,6 @@
-import 'dart:io';
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:http/http.dart' as http;
 
@@ -133,7 +133,7 @@ class Client {
       Uri.parse(
         'http://$runtimeApi/$runtimeApiVersion/runtime/invocation/$requestId/response',
       ),
-      body: jsonEncode(payload),
+      body: jsonEncode(payload.body),
     );
   }
 


### PR DESCRIPTION
I believe this is a bug. I was experiencing the same issue as reported here: https://github.com/awslabs/aws-lambda-dart-runtime/issues/28

Should be jsonEncoding payload.body not payload